### PR TITLE
DOPS-1643 add Linear team names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # Microsoft Graph SDK for Go
 
+## Service Metadata
+
+| Key                             | Value                          |
+|---------------------------------|--------------------------------|
+| **TEAM**                        | Team Name                      |
+| **TEAM-MANAGER-EMAIL**          | amit@nightfall.ai                     |
+| **SLACK-DEPLOY-NOTIFY-CHANNEL** | #deploy-notifications-channel  |
+| **SLACK-TEAM-CHANNEL**          | #team-slack-channel            |
+| **TEAM-LINEAR-SLUG**            | DTE                 |
+
+
 [![PkgGoDev](https://pkg.go.dev/badge/github.com/microsoftgraph/msgraph-sdk-go/)](https://pkg.go.dev/github.com/microsoftgraph/msgraph-sdk-go/)
 
 Get started with the Microsoft Graph SDK for Go by integrating the [Microsoft Graph API](https://docs.microsoft.com/graph/overview) into your Go application!

--- a/README.md
+++ b/README.md
@@ -4,12 +4,11 @@
 
 | Key                             | Value                          |
 |---------------------------------|--------------------------------|
-| **TEAM**                        | Team Name                      |
-| **TEAM-MANAGER-EMAIL**          | amit@nightfall.ai                     |
+| **TEAM**                        | Detection                      |
+| **TEAM-MANAGER-EMAIL**          | amit@nightfall.ai              |
 | **SLACK-DEPLOY-NOTIFY-CHANNEL** | #deploy-notifications-channel  |
 | **SLACK-TEAM-CHANNEL**          | #team-slack-channel            |
-| **TEAM-LINEAR-SLUG**            | DTE                 |
-
+| **TEAM-LINEAR-SLUG**            | DTE                            |
 
 [![PkgGoDev](https://pkg.go.dev/badge/github.com/microsoftgraph/msgraph-sdk-go/)](https://pkg.go.dev/github.com/microsoftgraph/msgraph-sdk-go/)
 


### PR DESCRIPTION
Updates README.md metadata table from repo_owners.csv.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds team/contact and Slack/Linear metadata to the README, with no impact to runtime behavior.
> 
> **Overview**
> Adds a new **Service Metadata** section to `README.md` containing ownership and support-routing fields (team name, manager email, Slack channels, and Linear slug). No code or SDK behavior is changed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0709f014d5360cb21832d62e5177ff1a65b9be3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->