### PR TITLE
Revert "DOPS-1643 add Linear team names"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,5 @@
 # Microsoft Graph SDK for Go
 
-## Service Metadata
-
-| Key                             | Value                          |
-|---------------------------------|--------------------------------|
-| **TEAM**                        | Detection                      |
-| **TEAM-MANAGER-EMAIL**          | amit@nightfall.ai              |
-| **SLACK-DEPLOY-NOTIFY-CHANNEL** | #deploy-notifications-channel  |
-| **SLACK-TEAM-CHANNEL**          | #team-slack-channel            |
-| **TEAM-LINEAR-SLUG**            | DTE                            |
-
 [![PkgGoDev](https://pkg.go.dev/badge/github.com/microsoftgraph/msgraph-sdk-go/)](https://pkg.go.dev/github.com/microsoftgraph/msgraph-sdk-go/)
 
 Get started with the Microsoft Graph SDK for Go by integrating the [Microsoft Graph API](https://docs.microsoft.com/graph/overview) into your Go application!


### PR DESCRIPTION
Reverts watchtowerai/msgraph-sdk-go#8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that removes internal team/contact metadata without affecting any code or runtime behavior.
> 
> **Overview**
> Removes the internal **Service Metadata** table (team/contact/Slack/Linear details) from `README.md`, leaving the public SDK usage and installation documentation unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit afaf549752e486d7edbe78da60ef6c1365fa7c6f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->